### PR TITLE
fix: fix lint issues on main build

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,6 +47,7 @@ tasks:
   lint:
     desc: "Run linters"
     cmds:
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
       - golangci-lint run
 
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/curt-hash/mkvbot
 
-go 1.23
+go 1.23.5
 
 require (
 	github.com/StalkR/imdb v1.0.16-0.20250113131526-e8846853d815
@@ -9,7 +9,6 @@ require (
 	github.com/go-playground/validator/v10 v10.24.0
 	github.com/rivo/tview v0.0.0-20241227133733-17b7edb88c57
 	github.com/urfave/cli/v3 v3.0.0-beta1
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	golang.org/x/sync v0.11.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDf
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
-golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=
-golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/pkg/makemkv/disc.go
+++ b/pkg/makemkv/disc.go
@@ -1,10 +1,10 @@
 package makemkv
 
 import (
+	"cmp"
 	"time"
 
 	"github.com/curt-hash/mkvbot/pkg/makemkv/defs"
-	"golang.org/x/exp/constraints"
 )
 
 // Disc is a sequence of titles plus some metadata.
@@ -68,7 +68,7 @@ func (d *Disc) TitlesWithMostStreams() []*Title {
 
 // Maximums returns all elements of the slice that maximize the given function,
 // i.e., where f(e) = max(f(e0), f(e1), ..., f(eN)).
-func Maximums[S []E, E any, V constraints.Ordered](s S, f func(E) (V, error)) S {
+func Maximums[S []E, E any, V cmp.Ordered](s S, f func(E) (V, error)) S {
 	var (
 		maxV     V
 		maximums S


### PR DESCRIPTION
Use the latest golangci-lint locally to match CI.